### PR TITLE
fix: constrain trl version to <=0.9.6 to resolve ValueError in SFTTrainer/SFTConfig

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ torch>=1.13.1
 transformers>=4.37.2
 peft>=0.10.0
 loguru
-trl>=0.9.3
+trl>=0.9.3,<=0.9.6
 bitsandbytes
 pyyaml


### PR DESCRIPTION
- Updated trl version requirement to be between 0.9.3 and 0.9.6.
- This change addresses the 'ValueError: You passed packing=False to the SFTTrainer/SFTConfig, but you didn't pass a dataset_text_field or formatting_func argument.' error caused by the latest version of trl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version specification for the `trl` package to ensure compatibility with specific features and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->