### PR TITLE
fix: constrain peft version to resolve LoraConfig initialization error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.13.1
 transformers>=4.43.0,<=4.45.0
-peft>=0.10.0
+peft>=0.10.0,<=0.13.2
 loguru
 trl>=0.9.3,<=0.9.6
 bitsandbytes


### PR DESCRIPTION
Constrained the version of the 'peft' library between 0.10.0 and 0.13.2 to address the error: `LoraConfig.__init__() got an unexpected keyword argument 'eva_config'`. This ensures compatibility with the validator script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version constraints for the `peft` package to include an upper limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->