### PR TITLE
fix: prevent empty tensor errors by handling missing assistant roles

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -79,6 +79,15 @@ class SFTDataset(Dataset):
                 target_mask += [0] * len(input_tokens) + [1] * len(output_tokens)
                 input_buffer = ""
 
+        # Process the last input_buffer if not empty and no assistant role was found
+        if input_buffer and len(input_ids) == 0:
+            logger.warning(f"Dataset item {index} has no assistant response. Using input buffer.")
+            input_tokens = self.tokenizer.encode(
+                input_buffer, add_special_tokens=False
+            )
+            input_ids = input_tokens
+            target_mask = [0] * len(input_tokens)
+
         assert len(input_ids) == len(target_mask)
 
         input_ids = input_ids[: self.max_seq_length]


### PR DESCRIPTION
- Added logic to use `input_buffer` for dataset items without an "assistant" role, ensuring non-empty `input_ids` and `target_mask`.
- Resolved tensor reshaping errors by preventing the creation of empty tensors.